### PR TITLE
- Fixed: s2c is no longer required to be in the PATH

### DIFF
--- a/s2cctl
+++ b/s2cctl
@@ -1,4 +1,6 @@
 #! /bin/sh
+logfile="$HOME/.Space2Ctrl.log"
+
 start() {
 	origmap=$(xmodmap -pke | grep -E "^keycode[[:blank:]]*?65")
 	#newmap=$(echo ${origmap} | perl -pe "s/65[[:blank:]]*?=[[:blank:]]*?space/65  = Control_L/")
@@ -6,10 +8,11 @@ start() {
 
 	xmodmap -e "$newmap"
 	xmodmap -e "keycode 255 = space VoidSymbol VoidSymbol VoidSymbol VoidSymbol"
-	nohup s2c >> ~/.Space2Ctrl.log 2>&1 &
+	nohup "${0%/*}/s2c" >> "$logfile" 2>&1 &
 	sleep 1 # Don't ask me why but we need to wait more than one second else the ctrl modifier is
 		# reinitialized to XK_Control_L XK_Control_R as soon as keycode 65 is pressed!
 	`xmodmap -e "add control = Control_L Control_R"`
+	echo "Space2Ctrl is now active (logfile: $logfile)"
 	exit 0
 }
 
@@ -26,10 +29,10 @@ stop() {
 
 case $1 in
 	start)
-		echo "Starting Space2Ctrl"
+		echo "Starting Space2Ctrl..."
 		start;;
 	stop)
-		echo "Stoping Space2Ctrl"
+		echo "Stopping Space2Ctrl..."
 		stop;;
 	*)
 		echo "Please pass start or stop";;


### PR DESCRIPTION
Should simplify troubleshooting when you try "make" with "make install". Then "./s2cctl start" silently fails because s2c is not in the PATH. Afterwards, space functions only as control but not as whitespace.

I modified the s2cctl script to assume that s2c is in the same directory as s2cctl. Additionally, the name of the logfile is printed at startup, which could also make troubleshooting easier.
