### PR TITLE
Fix compile error by swapping the include order

### DIFF
--- a/Space2Ctrl.cpp
+++ b/Space2Ctrl.cpp
@@ -17,11 +17,11 @@
 
 */
 
+#include <iostream>
 #include <X11/Xlibint.h>
 #include <X11/keysym.h>
 #include <X11/extensions/record.h>
 #include <X11/extensions/XTest.h>
-#include <iostream>
 #include <sys/time.h>
 #include <signal.h>
 


### PR DESCRIPTION
Swap include order as a workaround for the following error:

/usr/include/c++/6.2.1/bits/stl_algobase.h:243:56: error: macro "min" passed 3 arguments, but takes just 2
min(const _Tp& __a, const _Tp& __b, _Compare __comp)

Affects at least Arch Linux with gcc >=6.2.1 or clang. I have not looked too deep in the underlying cause, but I assume that one X11 headers defines some problematic macros.